### PR TITLE
time()-Buster entfernt

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -51,9 +51,9 @@ if (rex::isBackend() && rex::getUser()):
 	
 	//Backend-Anpassungen
 	if (@$config['be_minnav'] == 'checked'):
-		rex_view::addCssFile($this->getAssetsUrl('style.css?v='.time() ));
-		rex_view::addJsFile($this->getAssetsUrl('jquery.browser.min.js?v='.time() ));
-		rex_view::addJsFile($this->getAssetsUrl('script.js?v='.time() ));
+		rex_view::addCssFile($this->getAssetsUrl('style.css'));
+		rex_view::addJsFile($this->getAssetsUrl('jquery.browser.min.js'));
+		rex_view::addJsFile($this->getAssetsUrl('script.js'));
 	endif;
 	rex_extension::register('OUTPUT_FILTER', 'a1510_changeBE');
 
@@ -73,9 +73,9 @@ if (rex::isBackend() && rex::getUser()):
 		
 		if (($in > 0 || ($stcAll == 1 && $out <= 0)) && (@$config['be_tree'] == 'top' || $config['be_tree'] == 'left')):
 			rex_view::addCssFile($this->getAssetsUrl('rextree/jstree/themes/default/style.min.css?v='.time() ));
-			rex_view::addCssFile($this->getAssetsUrl('rextree/rextree.css?v='.time() ));
-			rex_view::addJsFile($this->getAssetsUrl('rextree/js.cookie.min.js?v='.time() ));
-			rex_view::addJsFile($this->getAssetsUrl('rextree/jstree/jstree.min.js?v='.time() ));
+			rex_view::addCssFile($this->getAssetsUrl('rextree/rextree.css'));
+			rex_view::addJsFile($this->getAssetsUrl('rextree/js.cookie.min.js'));
+			rex_view::addJsFile($this->getAssetsUrl('rextree/jstree/jstree.min.js'));
 			rex_extension::register('OUTPUT_FILTER', 'a1510_showTree');
 		endif;
 	endif;	

--- a/boot.php
+++ b/boot.php
@@ -72,7 +72,7 @@ if (rex::isBackend() && rex::getUser()):
 		$out = count(preg_grep('/^'.$page.'/i', $stcAllNot));
 		
 		if (($in > 0 || ($stcAll == 1 && $out <= 0)) && (@$config['be_tree'] == 'top' || $config['be_tree'] == 'left')):
-			rex_view::addCssFile($this->getAssetsUrl('rextree/jstree/themes/default/style.min.css?v='.time() ));
+			rex_view::addCssFile($this->getAssetsUrl('rextree/jstree/themes/default/style.min.css'));
 			rex_view::addCssFile($this->getAssetsUrl('rextree/rextree.css'));
 			rex_view::addJsFile($this->getAssetsUrl('rextree/js.cookie.min.js'));
 			rex_view::addJsFile($this->getAssetsUrl('rextree/jstree/jstree.min.js'));


### PR DESCRIPTION
fixes: https://github.com/FriendsOfREDAXO/be_tools/issues/6

Die Assets werden dann wie folgt eingebunden und REDAXO kümmert sich um den Buster. 

<img width="1111" alt="Bildschirmfoto 2019-10-24 um 16 28 28" src="https://user-images.githubusercontent.com/791247/67495592-707a8a00-f67b-11e9-8028-87fe1ee0609c.png">
